### PR TITLE
Update assert statements

### DIFF
--- a/aiopylgtv/lut_tools.py
+++ b/aiopylgtv/lut_tools.py
@@ -7,7 +7,7 @@ from .constants import BT2020_PRIMARIES, DV_CONFIG_FILENAMES
 
 
 def unity_lut_1d():
-    assert np, "numpy needs to be installed for this feature"
+    assert np  # numpy needs to be installed for this feature
     lutmono = np.linspace(0.0, 32767.0, 1024, dtype=np.float64)
     lut = np.stack([lutmono] * 3, axis=0)
     lut = np.rint(lut).astype(np.uint16)
@@ -15,7 +15,7 @@ def unity_lut_1d():
 
 
 def unity_lut_3d(n=33):
-    assert np, "numpy needs to be installed for this feature"
+    assert np  # numpy needs to be installed for this feature
     spacing = complex(0, n)
     endpoint = 4096.0
     lut = np.mgrid[0.0:endpoint:spacing, 0.0:endpoint:spacing, 0.0:endpoint:spacing]
@@ -27,7 +27,7 @@ def unity_lut_3d(n=33):
 
 
 def read_cube_file(filename):  # noqa: C901
-    assert np, "numpy needs to be installed for this feature"
+    assert np  # numpy needs to be installed for this feature
     nheader = 0
     lut_1d_size = None
     lut_3d_size = None
@@ -125,7 +125,7 @@ def read_cube_file(filename):  # noqa: C901
 
 
 def read_cal_file(filename):
-    assert np, "numpy needs to be installed for this feature"
+    assert np  # numpy needs to be installed for this feature
     with open(filename, "r") as f:
         caldata = f.readlines()
 
@@ -160,7 +160,7 @@ def read_cal_file(filename):
 
 
 def lms2rgb_matrix(primaries=BT2020_PRIMARIES):
-    assert np, "numpy needs to be installed for this feature"
+    assert np  # numpy needs to be installed for this feature
 
     xy = np.array(primaries, dtype=np.float64)
 
@@ -200,7 +200,7 @@ def create_dolby_vision_config(
     gamma=2.2,
     primaries=BT2020_PRIMARIES,
 ):
-    assert np, "numpy needs to be installed for this feature"
+    assert np  # numpy needs to be installed for this feature
 
     if not (white_level >= 100.0 and white_level <= 999.0):
         raise ValueError(

--- a/aiopylgtv/webos_client.py
+++ b/aiopylgtv/webos_client.py
@@ -1069,7 +1069,7 @@ class WebOsClient:
         await self.button(f"""{num}""")
 
     def validateCalibrationData(self, data, shape, dtype):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         if not isinstance(data, np.ndarray):
             raise TypeError(f"data must be of type ndarray but is instead {type(data)}")
         if data.shape != shape:
@@ -1082,7 +1082,7 @@ class WebOsClient:
             )
 
     async def calibration_request(self, command, picMode, data):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         dataenc = base64.b64encode(data.tobytes()).decode()
 
         payload = {
@@ -1100,17 +1100,17 @@ class WebOsClient:
         return await self.request(ep.CALIBRATION, payload)
 
     async def start_calibration(self, picMode, data=DEFAULT_CAL_DATA):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         self.validateCalibrationData(data, (9,), np.float32)
         return await self.calibration_request(cal.CAL_START, picMode, data)
 
     async def end_calibration(self, picMode, data=DEFAULT_CAL_DATA):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         self.validateCalibrationData(data, (9,), np.float32)
         return await self.calibration_request(cal.CAL_END, picMode, data)
 
     async def upload_1d_lut(self, picMode, data=None):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         info = self.calibration_support_info()
         if not info["lut1d"]:
             model = self._system_info["modelName"]
@@ -1123,7 +1123,7 @@ class WebOsClient:
         return await self.calibration_request(cal.UPLOAD_1D_LUT, picMode, data)
 
     async def upload_3d_lut(self, command, picMode, data):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         if command not in [cal.UPLOAD_3D_LUT_BT709, cal.UPLOAD_3D_LUT_BT2020]:
             raise PyLGTVCmdException(f"Invalid 3D LUT Upload command {command}.")
         info = self.calibration_support_info()
@@ -1142,15 +1142,15 @@ class WebOsClient:
         return await self.calibration_request(command, picMode, data)
 
     async def upload_3d_lut_bt709(self, picMode, data=None):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         return await self.upload_3d_lut(cal.UPLOAD_3D_LUT_BT709, picMode, data)
 
     async def upload_3d_lut_bt2020(self, picMode, data=None):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         return await self.upload_3d_lut(cal.UPLOAD_3D_LUT_BT2020, picMode, data)
 
     async def set_ui_data(self, command, picMode, value):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         if not (value >= 0 and value <= 100):
             raise ValueError
 
@@ -1158,44 +1158,44 @@ class WebOsClient:
         return await self.calibration_request(command, picMode, data)
 
     async def set_brightness(self, picMode, value):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         return await self.set_ui_data(cal.BRIGHTNESS_UI_DATA, picMode, value)
 
     async def set_contrast(self, picMode, value):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         return await self.set_ui_data(cal.CONTRAST_UI_DATA, picMode, value)
 
     async def set_oled_light(self, picMode, value):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         return await self.set_ui_data(cal.BACKLIGHT_UI_DATA, picMode, value)
 
     async def set_color(self, picMode, value):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         return await self.set_ui_data(cal.COLOR_UI_DATA, picMode, value)
 
     async def set_1d_2_2_en(self, picMode, value=0):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         data = np.array(value, dtype=np.uint16)
         return await self.calibration_request(
             cal.ENABLE_GAMMA_2_2_TRANSFORM, picMode, data
         )
 
     async def set_1d_0_45_en(self, picMode, value=0):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         data = np.array(value, dtype=np.uint16)
         return await self.calibration_request(
             cal.ENABLE_GAMMA_0_45_TRANSFORM, picMode, data
         )
 
     async def set_bt709_3by3_gamut_data(self, picMode, data=None):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         if data is None:
             data = np.identity(3, dtype=np.float32)
         self.validateCalibrationData(data, (3, 3), np.float32)
         return await self.calibration_request(cal.BT709_3BY3_GAMUT_DATA, picMode, data)
 
     async def set_bt2020_3by3_gamut_data(self, picMode, data=None):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         if data is None:
             data = np.identity(3, dtype=np.float32)
         self.validateCalibrationData(data, (3, 3), np.float32)
@@ -1204,7 +1204,7 @@ class WebOsClient:
     async def set_dolby_vision_config_data(
         self, white_level=700.0, black_level=0.0, gamma=2.2, primaries=BT2020_PRIMARIES
     ):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
 
         info = self.calibration_support_info()
         dv_config_type = info["dv_config_type"]
@@ -1242,7 +1242,7 @@ class WebOsClient:
         mastering_peak_3=10000,
         rolloff_point_3=50,
     ):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
 
         data = np.array(
             [
@@ -1260,7 +1260,7 @@ class WebOsClient:
         return await self.calibration_request(cal.SET_TONEMAP_PARAM, picMode, data)
 
     async def ddc_reset(self, picMode, reset_1d_lut=True):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         if not isinstance(reset_1d_lut, bool):
             raise TypeError(
                 f"reset_1d_lut should be a bool, instead got {reset_1d_lut} of type {type(reset_1d_lut)}."
@@ -1285,7 +1285,7 @@ class WebOsClient:
         return ret["settings"]
 
     async def upload_1d_lut_from_file(self, picMode, filename):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         ext = filename.split(".")[-1].lower()
         if ext == "cal":
             lut = await asyncio.get_running_loop().run_in_executor(
@@ -1303,7 +1303,7 @@ class WebOsClient:
         return await self.upload_1d_lut(picMode, lut)
 
     async def upload_3d_lut_from_file(self, command, picMode, filename):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         ext = filename.split(".")[-1].lower()
         if ext == "cube":
             lut = await asyncio.get_running_loop().run_in_executor(
@@ -1317,13 +1317,13 @@ class WebOsClient:
         return await self.upload_3d_lut(command, picMode, lut)
 
     async def upload_3d_lut_bt709_from_file(self, picMode, filename):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         return await self.upload_3d_lut_from_file(
             cal.UPLOAD_3D_LUT_BT709, picMode, filename
         )
 
     async def upload_3d_lut_bt2020_from_file(self, picMode, filename):
-        assert np, "numpy needs to be installed for this feature"
+        assert np  # numpy needs to be installed for this feature
         return await self.upload_3d_lut_from_file(
             cal.UPLOAD_3D_LUT_BT2020, picMode, filename
         )


### PR DESCRIPTION
Assert will always throw a `NameError`. Adding the string just means that Python asserts that the string is true.
Therefore I would like to change the string to a comment.

```bash
>>> assert np, "numpy needs to be installed for this feature"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'np' is not defined
```